### PR TITLE
Restructure `draw()` loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+examples/

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -1,4 +1,4 @@
-const preset = 'square'
+const preset = 'procreate-overlay'
 let fps = 5;
 let probSeedCol0Init = 0.05;
 let probSeedCol0Spawn = 0.002;
@@ -26,11 +26,17 @@ function presets(name) {
   let nPixelsCol;
   let res;
   let margins;
-  if (name == 'overlay') {
+  if (name == 'magma-overlay') {
     nPixelsRow = 1100;
     nPixelsCol = 2000;
     res = 10;
     margins = 110;
+  }
+  else if (name == 'procreate-overlay') {
+    nPixelsRow = 1100;
+    nPixelsCol = 2000;
+    res = 10;
+    margins = 150;
   }
   else if (name == 'square') {
     nPixelsRow = 500;

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -26,6 +26,16 @@ let save = false;
 let wait = 0;
 let nFrames = 100;
 
+a, b = preset('overlay');
+
+function preset(name) {
+  if (name === 'overlay') {
+    let a = 1;
+    let b = 2;
+  }
+  return a, b;
+}
+
 function setup() {
   createCanvas(nPixelsCol, nPixelsRow);
   console.log('setup');
@@ -49,6 +59,19 @@ function setup() {
     `frame_${('000' + frameCount).slice(-3)}`
   );
   console.log('end of setup')
+}
+
+function keyPressed() {
+  // Set spacebar to toggle play/pause of drawing loop
+  if (key === ' ') {
+    if (isLooping()) {
+      noLoop();
+    } else {
+      loop();
+    }
+  }
+  // Disable any default browser actions
+  return false;
 }
 
 function draw() {

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -1,12 +1,5 @@
-// let nPixelsRow = 1100;
-// let nPixelsCol = 2000;
-// let res = 10;
-let nPixelsRow = 2000;
-let nPixelsCol = 1100;
-let res = 10;
+const preset = 'square'
 let fps = 5;
-// let margins = 110;
-let margins = undefined;
 let probSeedCol0Init = 0.05;
 let probSeedCol0Spawn = 0.002;
 let probSeedCol0Beside = 0.45;
@@ -26,14 +19,26 @@ let save = false;
 let wait = 0;
 let nFrames = 100;
 
-a, b = preset('overlay');
+const [nPixelsRow, nPixelsCol, res, margins] = presets(preset);
 
-function preset(name) {
-  if (name === 'overlay') {
-    let a = 1;
-    let b = 2;
+function presets(name) {
+  let nPixelsRow;
+  let nPixelsCol;
+  let res;
+  let margins;
+  if (name == 'overlay') {
+    nPixelsRow = 1100;
+    nPixelsCol = 2000;
+    res = 10;
+    margins = 110;
   }
-  return a, b;
+  else if (name == 'square') {
+    nPixelsRow = 500;
+    nPixelsCol = 500;
+    res = 10;
+    margins = undefined;
+  }
+  return [nPixelsRow, nPixelsCol, res, margins];
 }
 
 function setup() {
@@ -75,7 +80,6 @@ function keyPressed() {
 }
 
 function draw() {
-  console.log(frameCount);
   background(bg[0], bg[1], bg[2]);
   //-------------//
   // Draw Clouds //

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -110,20 +110,23 @@ function draw() {
     // For clouds in column 1, sum probs for new column 0 seeds
     if (cloud.c == 1) {
       // Sum probs for seeds to form in col 0 directly beside live cells in col 1
-      probGrid, probLocs = cloud.besideProb(
-        probGrid, probLocs, probSeedCol0Beside
+      probGrid[cloud.r][0] = sumProb(
+        probGrid[cloud.r][cloud.c], probSeedCol0Beside
       );
+      probLocs.push([cloud.r, 0]);
       // Sum probs for seeds to form in col 0 above and beside live cells in col 1
       if (cloud.r != 0) {
-        probGrid, probLocs = cloud.topCornerProb(
-          probGrid, probLocs, probSeedCol0TopCorner
+        probGrid[cloud.r - 1][0] = sumProb(
+          probGrid[cloud.r - 1][0], probSeedCol0TopCorner
         );
+        probLocs.push([cloud.r - 1, 0]);
       }
       // Sum probs for seeds to form in col 0 below and beside live cells in col 1
       if (cloud.r != nRows - 1) {
-        probGrid, probLocs = cloud.bottomCornerProb(
-          probGrid, probLocs, probSeedCol0BottomCorner
+        probGrid[cloud.r + 1][0] = sumProb(
+          probGrid[cloud.r + 1][0], probSeedCol0BottomCorner
         );
+        probLocs.push([cloud.r + 1, 0]);
       }
     }
   }
@@ -132,17 +135,17 @@ function draw() {
   //------------//
   // Calculate probabilities to determine which cells need to be drawn
   for (let loc of probLocs) {
-    let seed = probGrid[loc[0]][loc[1]];
-    let cell = calcProb(seed.prob);
+    let prob = probGrid[loc[0]][loc[1]];
+    let cell = calcProb(prob);
     // If cell is to be turned from dead to alive, make a new Cloud object (cell is true in this case because it will be 1 and !liveCells[seed.r][seed.c] is true because seed location in liveCells was previously undefined)
-    if (cell && !liveCells[seed.r][seed.c]) {
+    if (cell && !liveCells[loc[0]][loc[1]]) {
       // Add a new cloud object to the clouds list
-      clouds.push(new Cloud(seed.r, seed.c, res));
-    } else if (!cell && liveCells[seed.r][seed.c]) {
-      cloudsToDelete[seed.r][seed.c] = 1;
+      clouds.push(new Cloud(loc[0], loc[1], res));
+    } else if (!cell && liveCells[loc[0]][loc[1]]) {
+      cloudsToDelete[loc[0]][loc[1]] = 1;
     }
     if (cell) {
-      liveCells[seed.r][seed.c] = 1;
+      liveCells[loc[0]][loc[1]] = 1;
     }
   }
   // Calculate the spawning of any new clouds


### PR DESCRIPTION
Restructuring the `draw()` loop includes:
- Combining previously separate `for` loops
- Replace grid of `seed` objects (`probSeedGrid`) with more simple grid of probability floats (`probGrid`)
- Simplifying summation of probabilities by removing overly-complex `cloud` methods